### PR TITLE
Bug fix/retrieve past activities on page load

### DIFF
--- a/Activity.js
+++ b/Activity.js
@@ -45,22 +45,9 @@ class Activity {
 
   markComplete() {
     this.completed = true;
-    // pastActivities.push(this);
-    // console.log(pastActivities);
   }
 
   saveToStorage() {
-    //save to pastActivities array
-    // var abc = JSON.stringify(pastActivities);
-    // localStorage.setItem('a', abc);
     localStorage.setItem(`${this.id}`, JSON.stringify(this));
-    // localStorage.getItem('abc', JSON.parse('abc'))
   }
-
-  // getFromStorage() {
-  //   var retrievedObject = localStorage.getItem(`${this.id}`);
-  //   var parsedObject = JSON.parse(retrievedObject);
-  //   var createPastActivity = new Activity(parsedObject.category, parsedObject.description, parsedObject.minutes, parsedObject.seconds)
-  //   pastActivities.push(createPastActivity);
-  // }
 };

--- a/Activity.js
+++ b/Activity.js
@@ -57,10 +57,10 @@ class Activity {
     // localStorage.getItem('abc', JSON.parse('abc'))
   }
 
-  getFromStorage() {
-    var retrievedObject = localStorage.getItem(`${this.id}`);
-    var parsedObject = JSON.parse(retrievedObject);
-    var createPastActivity = new Activity(parsedObject.category, parsedObject.description, parsedObject.minutes, parsedObject.seconds)
-    pastActivities.push(createPastActivity);
-  }
+  // getFromStorage() {
+  //   var retrievedObject = localStorage.getItem(`${this.id}`);
+  //   var parsedObject = JSON.parse(retrievedObject);
+  //   var createPastActivity = new Activity(parsedObject.category, parsedObject.description, parsedObject.minutes, parsedObject.seconds)
+  //   pastActivities.push(createPastActivity);
+  // }
 };

--- a/main.js
+++ b/main.js
@@ -75,6 +75,7 @@ window.onload = function() {
 function populatePastActivities() {
   pastActivities = [];
   var keys = Object.keys(localStorage);
+  sortDescending(keys);
   for (var i = 0; i < keys.length; i++) {
     var retrievedObject = localStorage.getItem(keys[i]);
     var parsedObject = JSON.parse(retrievedObject);
@@ -82,6 +83,12 @@ function populatePastActivities() {
     pastActivities.push(revivedPastActivity);
     // pastActivities.push(localStorage.getItem(keys[i]));
   }
+}
+
+function sortDescending(array) {
+  array.sort(function(a, b) {
+    return b - a;
+  });
 }
 
 // function populatePastActivities() {

--- a/main.js
+++ b/main.js
@@ -64,17 +64,34 @@ window.onload = function() {
   alert('Page Loaded');
   console.log(pastActivities);
   console.log(localStorage);
+  populatePastActivities();
+  displayPastActivities(); // new name of addPlaceHolderCard
+  hide(pastActivityMessage);
+  console.log(pastActivities);
+  console.log(localStorage);
 };
 
 // Add functions below
 function populatePastActivities() {
+  pastActivities = [];
   var keys = Object.keys(localStorage);
   for (var i = 0; i < keys.length; i++) {
-    pastActivities.push(localStorage.getItem(keys[i]));
+    var retrievedObject = localStorage.getItem(keys[i]);
+    var parsedObject = JSON.parse(retrievedObject);
+    var revivedPastActivity = new Activity(parsedObject.category, parsedObject.description, parsedObject.minutes, parsedObject.seconds);
+    pastActivities.push(revivedPastActivity);
+    // pastActivities.push(localStorage.getItem(keys[i]));
   }
-  // console.log(localStorage);
-  // console.log(pastActivities);
-};
+}
+
+// function populatePastActivities() {
+//   var keys = Object.keys(localStorage);
+//   for (var i = 0; i < keys.length; i++) {
+//     pastActivities.push(localStorage.getItem(keys[i]));
+//   }
+//   // console.log(localStorage);
+//   // console.log(pastActivities);
+// };
 
 function completeActivity() {
   document.querySelector('.congrats-msg').classList.remove('hidden');
@@ -95,17 +112,17 @@ function logActivityEvents() {
   pageHeader.innerText = "Completed Activity";
   startCircleText.innerText = "START";
   currentActivity.saveToStorage();
-  currentActivity.getFromStorage();
-  addPlaceholderCard();
+  // currentActivity.getFromStorage();
+  populatePastActivities();
+  displayPastActivities();
 }
 
 function createNewActivity() {
   currentActivity = new Activity(findCategoryChoice(), accomplishInput.value, parseInt(minutesInput.value), parseInt(secondsInput.value));
-  //save activities in localStorage or array??
 }
 
-function addPlaceholderCard() {
-  pastActivityCardHolder.innerHTML = ``;
+function displayPastActivities() {
+  pastActivityCardHolder.innerHTML = "";
   for (var i = 0; i < pastActivities.length; i++) {
     pastActivityCardHolder.innerHTML +=
       `<div class="past-activity-card">

--- a/main.js
+++ b/main.js
@@ -52,26 +52,30 @@ var pastActivities = [];
 
 //Add event listeners below
 categoryBoxWrapper.addEventListener('click', findCategory);
+
 startActivityButton.addEventListener('click', submitForm);
+
 startTimerButton.addEventListener('click', function() {
   startTimerButton.classList.add('cannot-click');
   currentActivity.startTimer();
 });
+
 logActivityButton.addEventListener('click', logActivityEvents);
+
 createNewActivityButton.addEventListener('click', returnToActivityForm);
 
+// Add functions below
 window.onload = function() {
   alert('Page Loaded');
   console.log(pastActivities);
   console.log(localStorage);
   populatePastActivities();
-  displayPastActivities(); // new name of addPlaceHolderCard
+  displayPastActivities();
   hide(pastActivityMessage);
   console.log(pastActivities);
   console.log(localStorage);
 };
 
-// Add functions below
 function populatePastActivities() {
   pastActivities = [];
   var keys = Object.keys(localStorage);
@@ -113,7 +117,6 @@ function logActivityEvents() {
   pageHeader.innerText = "Completed Activity";
   startCircleText.innerText = "START";
   currentActivity.saveToStorage();
-  // currentActivity.getFromStorage();
   populatePastActivities();
   displayPastActivities();
 }
@@ -294,7 +297,7 @@ function findCategory(event) {
     show(studyImageActive);
     show(meditateImage);
     show(exerciseImage);
-    document.querySelector('.circle-outline').style.borderColor = "#B3FD78";
+    startTimerButton.className = 'circle-outline circle-outline-study';
   } else if (event.target.classList.contains("radio-meditate")) {
     hide(studyImageActive);
     hide(exerciseImageActive);
@@ -302,7 +305,7 @@ function findCategory(event) {
     show(meditateImageActive);
     show(studyImage);
     show(exerciseImage);
-    document.querySelector('.circle-outline').style.borderColor = "#C278FD";
+    startTimerButton.className = 'circle-outline circle-outline-meditate';
   } else if (event.target.classList.contains("radio-exercise")) {
     hide(meditateImageActive);
     hide(studyImageActive);
@@ -310,6 +313,6 @@ function findCategory(event) {
     show(exerciseImageActive);
     show(meditateImage);
     show(studyImage);
-    document.querySelector('.circle-outline').style.borderColor = "#FD8078";
+    startTimerButton.className = 'circle-outline circle-outline-exercise';
   }
 }

--- a/main.js
+++ b/main.js
@@ -76,13 +76,7 @@ function populatePastActivities() {
   pastActivities = [];
   var keys = Object.keys(localStorage);
   sortDescending(keys);
-  for (var i = 0; i < keys.length; i++) {
-    var retrievedObject = localStorage.getItem(keys[i]);
-    var parsedObject = JSON.parse(retrievedObject);
-    var revivedPastActivity = new Activity(parsedObject.category, parsedObject.description, parsedObject.minutes, parsedObject.seconds);
-    pastActivities.push(revivedPastActivity);
-    // pastActivities.push(localStorage.getItem(keys[i]));
-  }
+  reviveActivitiesFromStorage(keys);
 }
 
 function sortDescending(array) {
@@ -91,14 +85,14 @@ function sortDescending(array) {
   });
 }
 
-// function populatePastActivities() {
-//   var keys = Object.keys(localStorage);
-//   for (var i = 0; i < keys.length; i++) {
-//     pastActivities.push(localStorage.getItem(keys[i]));
-//   }
-//   // console.log(localStorage);
-//   // console.log(pastActivities);
-// };
+function reviveActivitiesFromStorage(storedActivities) {
+  for (var i = 0; i < storedActivities.length; i++) {
+    var retrievedObject = localStorage.getItem(storedActivities[i]);
+    var parsedObject = JSON.parse(retrievedObject);
+    var revivedPastActivity = new Activity(parsedObject.category, parsedObject.description, parsedObject.minutes, parsedObject.seconds);
+    pastActivities.push(revivedPastActivity);
+  }
+}
 
 function completeActivity() {
   document.querySelector('.congrats-msg').classList.remove('hidden');

--- a/styles.css
+++ b/styles.css
@@ -110,6 +110,18 @@ timer-box-wrapper {
   width: 17vw;
 }
 
+.circle-outline-study {
+  border-color: #B3FD78;
+}
+
+.circle-outline-meditate {
+  border-color: #C278FD;
+}
+
+.circle-outline-exercise {
+  border-color: #FD8078;
+}
+
 .start-circle-text {
   text-align: center;
   font-size: 1.5rem;
@@ -299,7 +311,7 @@ form {
   color: #CBC9CF;
 }
 
-.past-activity-card { 
+.past-activity-card {
   border-radius: 5px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## **_PR TEMPLATE_**
1. Is this a fix or a feature?
* Fix

2. What is the change?
* Rearrange code so that past activities display on DOM when page reloads (in order!)
* Clean up comments
* Move hard-coded styles out of `main.js` and into `styles.css`

3. What does it fix?
* The past activities used to not show up on the DOM even though they existed in the `pastActivities` array

4. Where should the reviewer start?
* In `Activity.js`, `styles.css`, and `main.js`, look at the diffs -- most changes are just comments being removed.
* In `main.js` and `Activity.js`, follow the logic logging a current activity and saving it to storage, then retrieving all the activities in storage and using them to populate the `pastActivities` array, then displaying those past activities to the DOM right away and also on page load.

5. How should this be tested?
* Create and log several activities (make sure the circle is the right color each time), then reload the page and log a few more activities. Check that the panel of past activities looks right.
